### PR TITLE
fix instructor order

### DIFF
--- a/right_column.md
+++ b/right_column.md
@@ -4,8 +4,8 @@
 ### Instructors
 
 - Radovan Bast
-- Anne Fouilloux
 - Richard Darst
+- Anne Fouilloux
 - Sabry Razick
 
 


### PR DESCRIPTION
the current order was meaningless. Better to use alphabetical order (here by names).