### PR TITLE
left_column: Under schedule, link training material and manuals

### DIFF
--- a/left_column.md
+++ b/left_column.md
@@ -30,6 +30,11 @@ The focus of this workshop is on:
 
 ### Schedule
 
+Each workshop is a customized mix of material from our [instructor
+training
+material](https://coderefinery.github.io/instructor-training/) and
+[operations manuals](https://coderefinery.github.io/manuals/).
+
 #### Monday, Nov 2, 12:50 - 17:00 CET
 
 - 12:50 - 13:00


### PR DESCRIPTION
- Make it clear that we have a lot of material, and we present a
  customized version of it to each audience - so that people aren't
  surprised if we present almost straight from the manuals, too.
- Review: general check if this is a good idea.